### PR TITLE
Make sly-stepper a no-op for ABCL.

### DIFF
--- a/slynk-stepper.asd
+++ b/slynk-stepper.asd
@@ -8,7 +8,8 @@
                ;; #:agnostic-lizard
                )
   :description "Slynk part of the SLY/Emacs stepper tool."
-  :components ((:file "source-tracking-reader")
+  :components (#-armedbear
+               (:file "source-tracking-reader")
                (:file "slynk-stepper")))
 
 ;; Local Variables:

--- a/slynk-stepper.lisp
+++ b/slynk-stepper.lisp
@@ -223,6 +223,9 @@
                          debugp)
   "Return plists representing forms of interest inside STRING.
 If DEBUGP return information about the actual forms."
+  #+armedbear
+  (error "ABCL is unsupported")
+  #-armedbear
   (with-input-from-string (stream string)
     (let* ((ht-1 (make-hash-table))
            (form-tree


### PR DESCRIPTION
Gray streams on ABCL seem to be of the wrong type and do not work well with `slynk-gray`.

Until we figure this out, let's make sly-stepper a no-op for ABCL so that the
contrib can remained globally enabled (for other implementations).

Fixes #3.